### PR TITLE
fix: remove possible EOL in output

### DIFF
--- a/cmd/jwt/key2jwt.go
+++ b/cmd/jwt/key2jwt.go
@@ -60,7 +60,7 @@ func main() {
 			return
 		}
 	}
-	_, err = f.Write([]byte(jwt))
+	_, err = fmt.Fprintln(f, jwt)
 	if errClose := f.Close(); err == nil {
 		err = errClose
 	}


### PR DESCRIPTION
removes possible end of line character (`%`) from the output
<img width="72" alt="image" src="https://user-images.githubusercontent.com/9405495/200257227-60f65e79-4762-41fc-8188-024dba6ffa25.png">
