### PR TITLE
feat: add data import/export commands

### DIFF
--- a/cmd/data/data.go
+++ b/cmd/data/data.go
@@ -1,0 +1,27 @@
+package data
+
+import (
+	"github.com/spf13/cobra"
+	data_export "github.com/zitadel/zitadel-tools/cmd/data/export"
+	data_import "github.com/zitadel/zitadel-tools/cmd/data/import"
+)
+
+// Cmd represents the data root command
+var Cmd = &cobra.Command{
+	Use:   "data",
+	Short: "Import/Export data",
+}
+
+func init() {
+	issuer := Cmd.PersistentFlags().String("issuer", "", "issuer of your ZITADEL instance (in the form: https://<instance>.zitadel.cloud or https://<yourdomain>)")
+	api := Cmd.PersistentFlags().String("api", "", "gRPC endpoint of your ZITADEL instance (in the form: <instance>.zitadel.cloud:443 or <yourdomain>:443)")
+	insecure := Cmd.PersistentFlags().Bool("insecure", false, "disable TLS to connect to gRPC API (use for local development only)")
+	keyPath := Cmd.PersistentFlags().String("key", "", "path to the JSON machine key")
+
+	Cmd.MarkPersistentFlagRequired("issuer")
+	Cmd.MarkPersistentFlagRequired("api")
+	Cmd.MarkPersistentFlagRequired("key")
+
+	Cmd.AddCommand(data_import.Cmd(issuer, api, insecure, keyPath))
+	Cmd.AddCommand(data_export.Cmd(issuer, api, insecure, keyPath))
+}

--- a/cmd/data/export/export.go
+++ b/cmd/data/export/export.go
@@ -1,0 +1,81 @@
+package data_export
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/zitadel/zitadel-go/v2/pkg/client/admin"
+	"github.com/zitadel/zitadel-go/v2/pkg/client/middleware"
+	"github.com/zitadel/zitadel-go/v2/pkg/client/zitadel"
+	pb "github.com/zitadel/zitadel-go/v2/pkg/client/zitadel/admin"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+// Cmd represents the export command
+var Cmd = func(issuer *string, api *string, insecure *bool, keyPath *string) *cobra.Command {
+	var dataPath string
+
+	cmd := &cobra.Command{
+		Use:   "export",
+		Short: "Export data from an instance",
+		Run: func(cmd *cobra.Command, args []string) {
+			exportData(*issuer, *api, *insecure, *keyPath, dataPath)
+		},
+	}
+
+	cmd.Flags().StringVar(&dataPath, "data", "", "path to the file where exported data will be written")
+	cmd.MarkFlagRequired("data")
+
+	return cmd
+}
+
+func exportData(issuer string, api string, insecure bool, keyPath string, dataPath string) {
+	opts := []zitadel.Option{
+		zitadel.WithJWTProfileTokenSource(middleware.JWTProfileFromPath(keyPath)),
+	}
+
+	if insecure {
+		opts = append(opts, zitadel.WithInsecure())
+	}
+
+	client, err := admin.NewClient(
+		issuer,
+		api,
+		[]string{zitadel.ScopeZitadelAPI()},
+		opts...,
+	)
+
+	if err != nil {
+		log.Fatalln("failed to create admin client:", err)
+		return
+	}
+
+	defer func() {
+		if err := client.Connection.Close(); err != nil {
+			log.Fatalln("failed to close client connection:", err)
+		}
+	}()
+
+	resp, err := client.ExportData(context.Background(), &pb.ExportDataRequest{})
+
+	if err != nil {
+		log.Fatalln("failed to export data:", err)
+		return
+	}
+
+	data, err := protojson.Marshal(resp)
+
+	if err != nil {
+		log.Fatalln("failed to marshal data:", err)
+		return
+	}
+
+	err = os.WriteFile(dataPath, data, 0644)
+
+	if err != nil {
+		log.Fatalln("failed to write data file:", err)
+		return
+	}
+}

--- a/cmd/data/import/import.go
+++ b/cmd/data/import/import.go
@@ -1,0 +1,86 @@
+package data_import
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/zitadel/zitadel-go/v2/pkg/client/admin"
+	"github.com/zitadel/zitadel-go/v2/pkg/client/middleware"
+	"github.com/zitadel/zitadel-go/v2/pkg/client/zitadel"
+	pb "github.com/zitadel/zitadel-go/v2/pkg/client/zitadel/admin"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+// Cmd represents the import command
+var Cmd = func(issuer *string, api *string, insecure *bool, keyPath *string) *cobra.Command {
+	var dataPath string
+
+	cmd := &cobra.Command{
+		Use:   "import",
+		Short: "Import data to an instance",
+		Run: func(cmd *cobra.Command, args []string) {
+			importData(*issuer, *api, *insecure, *keyPath, dataPath)
+		},
+	}
+
+	cmd.Flags().StringVar(&dataPath, "data", "", "path to the file containing data to import")
+	cmd.MarkFlagRequired("data")
+
+	return cmd
+}
+
+func importData(issuer string, api string, insecure bool, keyPath string, dataPath string) {
+	opts := []zitadel.Option{
+		zitadel.WithJWTProfileTokenSource(middleware.JWTProfileFromPath(keyPath)),
+	}
+
+	if insecure {
+		opts = append(opts, zitadel.WithInsecure())
+	}
+
+	client, err := admin.NewClient(
+		issuer,
+		api,
+		[]string{zitadel.ScopeZitadelAPI()},
+		opts...,
+	)
+
+	if err != nil {
+		log.Fatalln("failed to create admin client:", err)
+		return
+	}
+
+	defer func() {
+		if err := client.Connection.Close(); err != nil {
+			log.Fatalln("failed to close client connection:", err)
+		}
+	}()
+
+	data, err := os.ReadFile(dataPath)
+
+	if err != nil {
+		log.Fatalln("failed to read data file:", err)
+		return
+	}
+
+	var req pb.ImportDataRequest
+
+	err = protojson.Unmarshal(data, &req)
+
+	if err != nil {
+		log.Fatalln("failed to unmarshal data:", err)
+		return
+	}
+
+	resp, err := client.ImportData(context.Background(), &req)
+
+	if err != nil {
+		log.Fatalln("failed to import data:", err)
+		return
+	}
+
+	log.Println("Success: ", resp.Success)
+	log.Println("Errors: ", resp.Errors)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/zitadel/zitadel-tools/cmd/basicauth"
+	"github.com/zitadel/zitadel-tools/cmd/data"
 	"github.com/zitadel/zitadel-tools/cmd/jwt"
 	"github.com/zitadel/zitadel-tools/cmd/migration"
 )
@@ -33,4 +34,5 @@ func init() {
 	rootCmd.AddCommand(jwt.Cmd)
 	rootCmd.AddCommand(basicauth.Cmd)
 	rootCmd.AddCommand(migration.Cmd)
+	rootCmd.AddCommand(data.Cmd)
 }


### PR DESCRIPTION
This simplifies the provisioning of local development environments. One can setup its organization, project, users, etc, and export instance data to a JSON file. Then, when creating a new development environment, the JSON file can be imported to the newly created instance.